### PR TITLE
Fix benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["api", "atom_generator", "definition_fetcher", "ffi"]
+resolver = "2"
 
 [workspace.package]
 rust-version = "1.64.0"

--- a/api/benches/common.rs
+++ b/api/benches/common.rs
@@ -1,4 +1,4 @@
-pub static UNIT_STRINGS: [&str; 25] = [
+pub const UNIT_STRINGS: [&str; 25] = [
     // The unity
     "1",
     // base, factor*base, factor*base^exponent
@@ -39,7 +39,7 @@ pub static UNIT_STRINGS: [&str; 25] = [
     "10m3/5s2",
 ];
 
-pub static UNIT_PAIRS: [(&str, &str); 19] = [
+pub const UNIT_PAIRS: [(&str, &str); 19] = [
     ("m", "m"),
     ("m", "cm"),
     ("m", "[in_i]"),

--- a/api/benches/measurements_benchmarks.rs
+++ b/api/benches/measurements_benchmarks.rs
@@ -4,46 +4,64 @@ extern crate wise_units;
 
 mod common;
 
-use criterion::Criterion;
+use criterion::{BenchmarkId, Criterion};
 use std::str::FromStr;
 use wise_units::{Convertible, Measurement, Unit};
 
 fn new_group(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "Measurement::try_new",
-        |b, &unit_string| {
-            b.iter(|| Measurement::try_new(1.0, unit_string));
-        },
-        &common::UNIT_STRINGS,
-    );
+    let mut group = c.benchmark_group("Measurement::try_new");
+
+    for unit_string in common::UNIT_STRINGS {
+        group.bench_with_input(
+            BenchmarkId::new("try_new", unit_string),
+            unit_string,
+            |b, unit_string| {
+                b.iter(|| Measurement::try_new(1.0, unit_string));
+            },
+        );
+    }
+
+    group.finish()
 }
 
 //-----------------------------------------------------------------------------
 // impl Convertible
 //-----------------------------------------------------------------------------
 fn convert_to_str_group(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "Measurement::convert_to(str)",
-        |b, &(lhs_string, rhs_string)| {
-            let lhs = Measurement::try_new(2.0, lhs_string).unwrap();
+    let mut group = c.benchmark_group("Measurement::convert_to<str>");
 
-            b.iter(|| lhs.convert_to(*rhs_string));
-        },
-        &common::UNIT_PAIRS,
-    );
+    for pair in common::UNIT_PAIRS {
+        group.bench_with_input(
+            BenchmarkId::new("convert_to", format!("{}->{}", pair.0, pair.1)),
+            &pair,
+            |b, (lhs_string, rhs_string)| {
+                let lhs = Measurement::try_new(2.0, *lhs_string).unwrap();
+
+                b.iter(|| lhs.convert_to(*rhs_string));
+            },
+        );
+    }
+
+    group.finish()
 }
 
 fn convert_to_unit_group(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "Measurement::convert_to(Unit)",
-        |b, &(lhs_string, rhs_string)| {
-            let lhs = Measurement::try_new(2.0, lhs_string).unwrap();
-            let rhs = &Unit::from_str(rhs_string).unwrap();
+    let mut group = c.benchmark_group("Measurement::convert_to<Unit>");
 
-            b.iter(|| lhs.convert_to(rhs));
-        },
-        &common::UNIT_PAIRS,
-    );
+    for pair in common::UNIT_PAIRS {
+        group.bench_with_input(
+            BenchmarkId::new("convert_to", format!("{}->{}", pair.0, pair.1)),
+            &pair,
+            |b, (lhs_string, rhs_string)| {
+                let lhs = Measurement::try_new(2.0, *lhs_string).unwrap();
+                let rhs = &Unit::from_str(rhs_string).unwrap();
+
+                b.iter(|| lhs.convert_to(rhs));
+            },
+        );
+    }
+
+    group.finish()
 }
 
 criterion_group!(
@@ -53,3 +71,4 @@ criterion_group!(
     convert_to_unit_group,
 );
 criterion_main!(measurement_benches);
+

--- a/api/benches/unit_benchmarks.rs
+++ b/api/benches/unit_benchmarks.rs
@@ -4,22 +4,28 @@ extern crate wise_units;
 
 mod common;
 
-use criterion::Criterion;
+use criterion::{BenchmarkId, Criterion};
 use std::str::FromStr;
 use wise_units::{Composable, IsCompatibleWith, UcumUnit, Unit};
 
 macro_rules! bench_over_inputs_method {
     ($function_name:ident, $test_name:expr, $method_name:ident) => {
         fn $function_name(c: &mut Criterion) {
-            c.bench_function_over_inputs(
-                $test_name,
-                |b, &unit_string| {
-                    let unit = Unit::from_str(unit_string).unwrap();
+            let mut group = c.benchmark_group($test_name);
 
-                    b.iter(|| unit.$method_name());
-                },
-                &common::UNIT_STRINGS,
-            );
+            for unit_string in common::UNIT_STRINGS {
+                group.bench_with_input(
+                    BenchmarkId::new(stringify!($method_name), &unit_string),
+                    unit_string,
+                    |b, unit_string| {
+                        let unit = Unit::from_str(unit_string).unwrap();
+
+                        b.iter(|| unit.$method_name());
+                    },
+                );
+            }
+
+            group.finish()
         }
     };
 }
@@ -27,12 +33,22 @@ macro_rules! bench_over_inputs_method {
 macro_rules! bench_over_inputs_math {
     ($function_name:ident, $test_name:expr, $method_name:tt) => {
         fn $function_name(c: &mut Criterion) {
-            c.bench_function_over_inputs($test_name, |b, &(lhs_string, rhs_string)| {
-                let lhs = &Unit::from_str(lhs_string).unwrap();
-                let rhs = &Unit::from_str(rhs_string).unwrap();
+            let mut group = c.benchmark_group($test_name);
 
-                b.iter(|| lhs $method_name rhs);
-            }, &common::UNIT_PAIRS);
+            for pair in common::UNIT_PAIRS {
+                group.bench_with_input(
+                    BenchmarkId::new(stringify!($method_name), format!("{}->{}", pair.0, pair.1)),
+                    &pair,
+                    |b, (lhs_string, rhs_string)| {
+                        let lhs = &Unit::from_str(lhs_string).unwrap();
+                        let rhs = &Unit::from_str(rhs_string).unwrap();
+
+                        b.iter(|| lhs $method_name rhs);
+                    },
+                );
+            }
+
+            group.finish()
         }
     };
 }
@@ -54,16 +70,22 @@ bench_over_inputs_method!(
 bench_over_inputs_method!(composition_group, "Unit::composition()", composition);
 
 fn is_compatible_with_group(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "Unit::is_compatible_with()",
-        |b, &(lhs_string, rhs_string)| {
-            let lhs = &Unit::from_str(lhs_string).unwrap();
-            let rhs = &Unit::from_str(rhs_string).unwrap();
+    let mut group = c.benchmark_group("Unit::is_compatible_with()");
 
-            b.iter(|| lhs.is_compatible_with(rhs));
-        },
-        &common::UNIT_PAIRS,
-    );
+    for pair in common::UNIT_PAIRS {
+        group.bench_with_input(
+            BenchmarkId::new("is_compatible_with", format!("{}->{}", pair.0, pair.1)),
+            &pair,
+            |b, (lhs_string, rhs_string)| {
+                let lhs = &Unit::from_str(lhs_string).unwrap();
+                let rhs = &Unit::from_str(rhs_string).unwrap();
+
+                b.iter(|| lhs.is_compatible_with(rhs));
+            },
+        );
+    }
+
+    group.finish()
 }
 
 //-----------------------------------------------------------------------------
@@ -75,13 +97,19 @@ bench_over_inputs_method!(display_group, "Unit::to_string()", to_string);
 // impl FromStr
 //-----------------------------------------------------------------------------
 fn from_str_group(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "Unit::from_str()",
-        |b, &unit_string| {
-            b.iter(|| Unit::from_str(unit_string));
-        },
-        &common::UNIT_STRINGS,
-    );
+    let mut group = c.benchmark_group("Unit::from_str()");
+
+    for unit_string in common::UNIT_STRINGS {
+        group.bench_with_input(
+            BenchmarkId::new("from_str", unit_string),
+            unit_string,
+            |b, unit_string| {
+                b.iter(|| Unit::from_str(unit_string));
+            },
+        );
+    }
+
+    group.finish()
 }
 
 //-----------------------------------------------------------------------------
@@ -121,3 +149,4 @@ criterion_group!(
     partial_ord_gt_group,
 );
 criterion_main!(unit_benches);
+


### PR DESCRIPTION
Update bencharks to work with current `criterion`. Also set `resolver = 2` in the workspace
Cargo.toml.
