### PR TITLE
PLCC-299 Add term::{Factor, Exponent} type aliases

### DIFF
--- a/crates/api/CHANGELOG.md
+++ b/crates/api/CHANGELOG.md
@@ -22,6 +22,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `unit` constant: `UNITY`
 - Added `term` constants: `UNITY`, `UNITY_ARRAY`, and `UNITY_ARRAY_REF`.
 - Added `measurement!()` macro for wrapping `Measurement::try_new().unwrap()`.
+- Added `crate::parser::term::Factor` type alias for `u32`.
+- Added `crate::parser::term::Exponent` type alias for `i32`.
 
 ### Changed
 

--- a/crates/api/src/measurement/num_traits/pow.rs
+++ b/crates/api/src/measurement/num_traits/pow.rs
@@ -1,11 +1,11 @@
 use num_traits::Pow;
 
-use crate::Measurement;
+use crate::{parser::term::Exponent, Measurement};
 
-impl Pow<i32> for Measurement {
+impl Pow<Exponent> for Measurement {
     type Output = Self;
 
-    fn pow(self, rhs: i32) -> Self::Output {
+    fn pow(self, rhs: Exponent) -> Self::Output {
         Self {
             value: self.value.pow(rhs),
             unit: self.unit.pow(rhs),
@@ -13,10 +13,10 @@ impl Pow<i32> for Measurement {
     }
 }
 
-impl<'a> Pow<i32> for &'a Measurement {
+impl<'a> Pow<Exponent> for &'a Measurement {
     type Output = Measurement;
 
-    fn pow(self, rhs: i32) -> Self::Output {
+    fn pow(self, rhs: Exponent) -> Self::Output {
         Measurement {
             value: self.value.pow(rhs),
             unit: self.unit.clone().pow(rhs),
@@ -24,10 +24,10 @@ impl<'a> Pow<i32> for &'a Measurement {
     }
 }
 
-impl<'a> Pow<i32> for &'a mut Measurement {
+impl<'a> Pow<Exponent> for &'a mut Measurement {
     type Output = Self;
 
-    fn pow(self, rhs: i32) -> Self::Output {
+    fn pow(self, rhs: Exponent) -> Self::Output {
         self.value = self.value.pow(rhs);
         let _ = Pow::pow(&mut self.unit, rhs);
         self

--- a/crates/api/src/parser/annotation_composition.rs
+++ b/crates/api/src/parser/annotation_composition.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-pub type AnnotationComposition = HashMap<String, i32>;
+use super::term::Exponent;
+
+pub type AnnotationComposition = HashMap<String, Exponent>;
 
 /// Similar to `Composable`, this is only to allow for checking compatibility on `Unit`s that have
 /// annotations. For those cases, we want to be able to ensure that, for example, `m{foo}` is not

--- a/crates/api/src/parser/composition.rs
+++ b/crates/api/src/parser/composition.rs
@@ -1,7 +1,5 @@
-use super::Dimension;
+use super::{term::Exponent, Dimension};
 use std::{fmt, ops::Mul};
-
-type Exponent = i32;
 
 pub const DIMLESS: Composition = Composition::new_dimless();
 
@@ -78,8 +76,8 @@ pub struct Composition {
 macro_rules! def_mul_exponent {
     ($meth_name:ident, $composition_method:ident) => {
         fn $meth_name(
-            original_value: Option<i32>,
-            exponent: i32,
+            original_value: Option<Exponent>,
+            exponent: Exponent,
             new_composition: &mut Composition,
         ) {
             if let Some(self_exponent) = original_value {
@@ -107,7 +105,7 @@ macro_rules! insert_exponent {
 macro_rules! def_add_dimension {
     ($meth_name:ident, $composition_method:ident) => {
         fn $meth_name(
-            original_value: Option<i32>,
+            original_value: Option<Exponent>,
             rhs_composition: Composition,
             new_composition: &mut Composition,
         ) {
@@ -122,7 +120,7 @@ macro_rules! def_add_dimension {
 
 impl Composition {
     #[must_use]
-    pub const fn new(dimension: Dimension, exponent: i32) -> Self {
+    pub const fn new(dimension: Dimension, exponent: Exponent) -> Self {
         match dimension {
             Dimension::ElectricCharge => Self::new_electric_charge(exponent),
             Dimension::Length => Self::new_length(exponent),
@@ -148,7 +146,7 @@ impl Composition {
     }
 
     #[must_use]
-    pub const fn new_electric_charge(exponent: i32) -> Self {
+    pub const fn new_electric_charge(exponent: Exponent) -> Self {
         Self {
             electric_charge: Some(exponent),
             length: None,
@@ -161,7 +159,7 @@ impl Composition {
     }
 
     #[must_use]
-    pub const fn new_length(exponent: i32) -> Self {
+    pub const fn new_length(exponent: Exponent) -> Self {
         Self {
             electric_charge: None,
             length: Some(exponent),
@@ -174,7 +172,7 @@ impl Composition {
     }
 
     #[must_use]
-    pub const fn new_luminous_intensity(exponent: i32) -> Self {
+    pub const fn new_luminous_intensity(exponent: Exponent) -> Self {
         Self {
             electric_charge: None,
             length: None,
@@ -187,7 +185,7 @@ impl Composition {
     }
 
     #[must_use]
-    pub const fn new_mass(exponent: i32) -> Self {
+    pub const fn new_mass(exponent: Exponent) -> Self {
         Self {
             electric_charge: None,
             length: None,
@@ -200,7 +198,7 @@ impl Composition {
     }
 
     #[must_use]
-    pub const fn new_plane_angle(exponent: i32) -> Self {
+    pub const fn new_plane_angle(exponent: Exponent) -> Self {
         Self {
             electric_charge: None,
             length: None,
@@ -213,7 +211,7 @@ impl Composition {
     }
 
     #[must_use]
-    pub const fn new_temperature(exponent: i32) -> Self {
+    pub const fn new_temperature(exponent: Exponent) -> Self {
         Self {
             electric_charge: None,
             length: None,
@@ -226,7 +224,7 @@ impl Composition {
     }
 
     #[must_use]
-    pub const fn new_time(exponent: i32) -> Self {
+    pub const fn new_time(exponent: Exponent) -> Self {
         Self {
             electric_charge: None,
             length: None,
@@ -240,13 +238,13 @@ impl Composition {
 
     #[must_use]
     pub const fn new_any(
-        electric_charge: Option<i32>,
-        length: Option<i32>,
-        luminous_intensity: Option<i32>,
-        mass: Option<i32>,
-        plane_angle: Option<i32>,
-        temperature: Option<i32>,
-        time: Option<i32>,
+        electric_charge: Option<Exponent>,
+        length: Option<Exponent>,
+        luminous_intensity: Option<Exponent>,
+        mass: Option<Exponent>,
+        plane_angle: Option<Exponent>,
+        temperature: Option<Exponent>,
+        time: Option<Exponent>,
     ) -> Self {
         Self {
             electric_charge,
@@ -259,7 +257,7 @@ impl Composition {
         }
     }
 
-    pub fn insert(&mut self, dimension: Dimension, exponent: i32) {
+    pub fn insert(&mut self, dimension: Dimension, exponent: Exponent) {
         if exponent == 0 {
             return;
         }
@@ -275,31 +273,31 @@ impl Composition {
         }
     }
 
-    fn insert_electric_charge(&mut self, exponent: i32) {
+    fn insert_electric_charge(&mut self, exponent: Exponent) {
         self.electric_charge = insert_exponent!(self, electric_charge, exponent);
     }
 
-    fn insert_length(&mut self, exponent: i32) {
+    fn insert_length(&mut self, exponent: Exponent) {
         self.length = insert_exponent!(self, length, exponent);
     }
 
-    fn insert_luminous_intensity(&mut self, exponent: i32) {
+    fn insert_luminous_intensity(&mut self, exponent: Exponent) {
         self.luminous_intensity = insert_exponent!(self, luminous_intensity, exponent);
     }
 
-    fn insert_mass(&mut self, exponent: i32) {
+    fn insert_mass(&mut self, exponent: Exponent) {
         self.mass = insert_exponent!(self, mass, exponent);
     }
 
-    fn insert_plane_angle(&mut self, exponent: i32) {
+    fn insert_plane_angle(&mut self, exponent: Exponent) {
         self.plane_angle = insert_exponent!(self, plane_angle, exponent);
     }
 
-    fn insert_temperature(&mut self, exponent: i32) {
+    fn insert_temperature(&mut self, exponent: Exponent) {
         self.temperature = insert_exponent!(self, temperature, exponent);
     }
 
-    fn insert_time(&mut self, exponent: i32) {
+    fn insert_time(&mut self, exponent: Exponent) {
         self.time = insert_exponent!(self, time, exponent);
     }
 
@@ -337,7 +335,7 @@ impl fmt::Display for Composition {
 }
 
 fn push_display_expression(
-    composition_value: Option<i32>,
+    composition_value: Option<Exponent>,
     expressions: &mut Vec<String>,
     dimension_str: &str,
 ) {
@@ -399,10 +397,10 @@ def_add_dimension!(add_time, time);
 /// assert_eq!(&t.composition().to_string(), "L6");
 /// ```
 ///
-impl Mul<i32> for Composition {
+impl Mul<Exponent> for Composition {
     type Output = Self;
 
-    fn mul(self, rhs: i32) -> Self::Output {
+    fn mul(self, rhs: Exponent) -> Self::Output {
         let mut new_composition = Self::default();
 
         mul_electric_charge(self.electric_charge, rhs, &mut new_composition);
@@ -428,7 +426,7 @@ def_mul_exponent!(mul_time, time);
 /// Used internally for disallowing setting any of the dimensions' exponents to 0 (it should
 /// be `None` in that case).
 ///
-const fn set_exponent(exponent: i32) -> Option<i32> {
+const fn set_exponent(exponent: Exponent) -> Option<Exponent> {
     if exponent == 0 {
         None
     } else {

--- a/crates/api/src/parser/term.rs
+++ b/crates/api/src/parser/term.rs
@@ -23,6 +23,9 @@ pub const UNITY: Term = {
 pub const UNITY_ARRAY: [Term; 1] = [UNITY];
 pub const UNITY_ARRAY_REF: &[Term; 1] = &UNITY_ARRAY;
 
+pub type Factor = u32;
+pub type Exponent = i32;
+
 /// A Term makes up an Atom (at its core) along with any Atom modifiers
 /// (anything that can change its scalar). It is, however, possible to have an
 /// Atom-less Term, which would simple be a Factor (with or without an
@@ -30,10 +33,10 @@ pub const UNITY_ARRAY_REF: &[Term; 1] = &UNITY_ARRAY;
 ///
 #[derive(Clone, Debug, Eq, Default)]
 pub struct Term {
-    pub factor: Option<u32>,
+    pub factor: Option<Factor>,
     pub prefix: Option<Prefix>,
     pub atom: Option<Atom>,
-    pub exponent: Option<i32>,
+    pub exponent: Option<Exponent>,
     pub annotation: Option<String>,
 }
 
@@ -115,7 +118,7 @@ impl Term {
         }
     }
 
-    pub fn factor_and_is_not_one<F: FnOnce(u32)>(&self, f: F) {
+    pub fn factor_and_is_not_one<F: FnOnce(Factor)>(&self, f: F) {
         if let Some(factor) = self.factor {
             if factor != 1 {
                 f(factor);
@@ -124,7 +127,7 @@ impl Term {
     }
 
     #[must_use]
-    pub fn factor_as_u32(&self) -> u32 {
+    pub fn factor_as_u32(&self) -> Factor {
         self.factor.unwrap_or(1)
     }
 }

--- a/crates/api/src/parser/term/display.rs
+++ b/crates/api/src/parser/term/display.rs
@@ -1,5 +1,6 @@
-use super::Term;
 use std::fmt;
+
+use super::{Factor, Term};
 
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -23,7 +24,7 @@ fn extract_term_string(term: &Term) -> String {
     term_string
 }
 
-fn extract_term_string_factor(term_string: &mut String, term_factor: Option<u32>) {
+fn extract_term_string_factor(term_string: &mut String, term_factor: Option<Factor>) {
     if let Some(factor) = term_factor {
         if factor != 1 {
             term_string.push_str(&factor.to_string());

--- a/crates/api/src/parser/term/num_traits/pow.rs
+++ b/crates/api/src/parser/term/num_traits/pow.rs
@@ -1,11 +1,11 @@
 use num_traits::Pow;
 
-use crate::Term;
+use crate::{parser::term::Exponent, Term};
 
-impl Pow<i32> for Term {
+impl Pow<Exponent> for Term {
     type Output = Self;
 
-    fn pow(self, rhs: i32) -> Self::Output {
+    fn pow(self, rhs: Exponent) -> Self::Output {
         let exponent = self.exponent.map_or(rhs, |exp| exp * rhs);
 
         Self {
@@ -18,10 +18,10 @@ impl Pow<i32> for Term {
     }
 }
 
-impl<'a> Pow<i32> for &'a Term {
+impl<'a> Pow<Exponent> for &'a Term {
     type Output = Term;
 
-    fn pow(self, rhs: i32) -> Self::Output {
+    fn pow(self, rhs: Exponent) -> Self::Output {
         let exponent = self.exponent.map_or(rhs, |exp| exp * rhs);
 
         Term {
@@ -34,10 +34,10 @@ impl<'a> Pow<i32> for &'a Term {
     }
 }
 
-impl<'a> Pow<i32> for &'a mut Term {
+impl<'a> Pow<Exponent> for &'a mut Term {
     type Output = Self;
 
-    fn pow(self, rhs: i32) -> Self::Output {
+    fn pow(self, rhs: Exponent) -> Self::Output {
         self.exponent = Some(self.exponent.map_or(rhs, |exp| exp * rhs));
 
         self

--- a/crates/api/src/parser/term/reducible.rs
+++ b/crates/api/src/parser/term/reducible.rs
@@ -4,7 +4,7 @@ use num_traits::One;
 
 use crate::{parser::ucum_symbol::UcumSymbol, reducible::Reducible};
 
-use super::Term;
+use super::{Exponent, Factor, Term};
 
 impl Reducible<f64> for Term {
     fn reduce_value(&self, value: f64) -> f64 {
@@ -40,8 +40,8 @@ impl<'a> Reducible<f64> for Cow<'a, [Term]> {
 fn combine_term_values(
     calculated_atom: f64,
     calculated_prefix: f64,
-    factor: Option<u32>,
-    exponent: Option<i32>,
+    factor: Option<Factor>,
+    exponent: Option<Exponent>,
 ) -> f64 {
     let a_p_product = calculated_atom * calculated_prefix;
 

--- a/crates/api/src/parser/terms/mapper.rs
+++ b/crates/api/src/parser/terms/mapper.rs
@@ -18,7 +18,7 @@ mod simple_unit;
 use self::{
     annotatable::Annotatable, annotation::Annotation, ast_term::AstTerm,
     basic_component::BasicComponent, component::Component, digits::Digits, exponent::Exponent,
-    factor::Factor, finishable::Finishable, main_term::MainTerm, simple_unit::SimpleUnit,
+    finishable::Finishable, main_term::MainTerm, simple_unit::SimpleUnit,
 };
 use crate::parser::{terms::term_parser::Rule, Atom, Error, Prefix, Term, Visit};
 use pest::iterators::{Pair, Pairs};

--- a/crates/api/src/parser/terms/mapper/annotatable.rs
+++ b/crates/api/src/parser/terms/mapper/annotatable.rs
@@ -1,12 +1,14 @@
-use super::{Atom, Error, Exponent, Prefix, SimpleUnit, Visit};
-use crate::parser::terms::term_parser::Rule as TermRule;
 use pest::iterators::Pair;
+
+use crate::parser::{term::Exponent as IExponent, terms::term_parser::Rule as TermRule};
+
+use super::{Atom, Error, Exponent, Prefix, SimpleUnit, Visit};
 
 pub(super) enum Annotatable {
     PrefixedWithExponent {
         prefix: Prefix,
         atom: Atom,
-        exponent: i32,
+        exponent: IExponent,
     },
     Prefixed {
         prefix: Prefix,
@@ -14,7 +16,7 @@ pub(super) enum Annotatable {
     },
     BasicWithExponent {
         atom: Atom,
-        exponent: i32,
+        exponent: IExponent,
     },
     Basic {
         atom: Atom,

--- a/crates/api/src/parser/terms/mapper/basic_component.rs
+++ b/crates/api/src/parser/terms/mapper/basic_component.rs
@@ -1,9 +1,11 @@
-use super::{Annotatable, Annotation, AstTerm, Error, Factor, Finishable, Term, Visit};
-use crate::parser::terms::term_parser::Rule;
 use pest::iterators::Pair;
 
+use crate::parser::{term::Factor, terms::term_parser::Rule};
+
+use super::{Annotatable, Annotation, AstTerm, Error, Finishable, Term, Visit};
+
 pub(super) struct BasicComponent {
-    pub(super) factor: Option<u32>,
+    pub(super) factor: Option<Factor>,
     pub(super) annotatable: Option<Annotatable>,
     pub(super) annotation: Option<String>,
     pub(super) terms: Vec<Term>,
@@ -68,7 +70,7 @@ impl Visit<Rule> for BasicComponent {
 
 enum FirstToken {
     Annotatable(Annotatable),
-    Factor(u32),
+    Factor(Factor),
 }
 
 impl Finishable for BasicComponent {

--- a/crates/api/src/parser/terms/mapper/component.rs
+++ b/crates/api/src/parser/terms/mapper/component.rs
@@ -1,9 +1,11 @@
-use super::{BasicComponent, Error, Factor, Finishable, Term, Visit};
-use crate::parser::terms::term_parser::Rule;
 use pest::iterators::Pair;
 
+use crate::parser::{term::Factor, terms::term_parser::Rule};
+
+use super::{BasicComponent, Error, Finishable, Term, Visit};
+
 pub(super) struct Component {
-    pub(super) factor: Option<u32>,
+    pub(super) factor: Option<Factor>,
     pub(super) terms: Vec<Term>,
 }
 

--- a/crates/api/src/parser/terms/mapper/exponent.rs
+++ b/crates/api/src/parser/terms/mapper/exponent.rs
@@ -1,8 +1,10 @@
-use super::{Digits, Error, Visit};
-use crate::parser::terms::term_parser::Rule as TermRule;
 use pest::iterators::Pair;
 
-pub(super) struct Exponent(pub(super) i32);
+use crate::parser::{term, terms::term_parser::Rule as TermRule};
+
+use super::{Digits, Error, Visit};
+
+pub(super) struct Exponent(pub(super) term::Exponent);
 
 impl Visit<TermRule> for Exponent {
     fn visit(pair: Pair<'_, TermRule>) -> Result<Self, Error> {
@@ -48,5 +50,5 @@ fn parse_second_token(next: Option<Pair<'_, TermRule>>) -> Result<Digits, Error>
 enum FirstToken {
     PositiveSign,
     NegativeSign,
-    Exponent(i32),
+    Exponent(term::Exponent),
 }

--- a/crates/api/src/parser/terms/mapper/factor.rs
+++ b/crates/api/src/parser/terms/mapper/factor.rs
@@ -1,10 +1,10 @@
-use super::{Error, Visit};
-use crate::parser::terms::term_parser::Rule as TermRule;
 use pest::iterators::Pair;
 
-pub(super) type Factor = u32;
+use crate::parser::{term, terms::term_parser::Rule as TermRule};
 
-impl Visit<TermRule> for Factor {
+use super::{Error, Visit};
+
+impl Visit<TermRule> for term::Factor {
     fn visit(pair: Pair<'_, TermRule>) -> Result<Self, Error> {
         pair.as_span().as_str().parse::<Self>().map_err(Error::from)
     }

--- a/crates/api/src/unit/num_traits/pow.rs
+++ b/crates/api/src/unit/num_traits/pow.rs
@@ -1,11 +1,11 @@
 use num_traits::Pow;
 
-use crate::Unit;
+use crate::{parser::term::Exponent, Unit};
 
-impl Pow<i32> for Unit {
+impl Pow<Exponent> for Unit {
     type Output = Self;
 
-    fn pow(self, rhs: i32) -> Self::Output {
+    fn pow(self, rhs: Exponent) -> Self::Output {
         Self::new(
             self.terms
                 .iter()
@@ -16,10 +16,10 @@ impl Pow<i32> for Unit {
     }
 }
 
-impl<'a> Pow<i32> for &'a Unit {
+impl<'a> Pow<Exponent> for &'a Unit {
     type Output = Unit;
 
-    fn pow(self, rhs: i32) -> Self::Output {
+    fn pow(self, rhs: Exponent) -> Self::Output {
         Unit::new(
             self.terms
                 .iter()
@@ -29,10 +29,10 @@ impl<'a> Pow<i32> for &'a Unit {
     }
 }
 
-impl<'a> Pow<i32> for &'a mut Unit {
+impl<'a> Pow<Exponent> for &'a mut Unit {
     type Output = Self;
 
-    fn pow(self, rhs: i32) -> Self::Output {
+    fn pow(self, rhs: Exponent) -> Self::Output {
         self.terms.to_mut().iter_mut().for_each(|term| {
             let _ = Pow::pow(term, rhs);
         });

--- a/crates/api/src/unit/term_reducing.rs
+++ b/crates/api/src/unit/term_reducing.rs
@@ -1,13 +1,17 @@
+use std::collections::BTreeMap;
+
 use num_traits::Zero;
 
-use crate::parser::{term, Atom, Prefix, Term};
-use std::collections::BTreeMap;
+use crate::parser::{
+    term::{self, Exponent, Factor},
+    Atom, Prefix, Term,
+};
 
 /// Internal struct used for reducing `Term`s.
 ///
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct ComposableTerm {
-    factor: Option<u32>,
+    factor: Option<Factor>,
     prefix: Option<Prefix>,
     atom: Option<Atom>,
     annotation: Option<String>,
@@ -30,7 +34,7 @@ impl<'a> From<&'a Term> for ComposableTerm {
     }
 }
 
-type Parts = (ComposableTerm, i32);
+type Parts = (ComposableTerm, Exponent);
 
 impl From<Parts> for Term {
     fn from(parts: Parts) -> Self {
@@ -64,7 +68,7 @@ pub(super) fn reduce_terms(terms: &[Term]) -> Vec<Term> {
 /// uniqueness (`atom`, `prefix`, `factor`), and sums those exponents. This is the destructuring
 /// part of `reduce_terms()`.
 ///
-fn reduce_to_map(terms: &[Term]) -> BTreeMap<ComposableTerm, i32> {
+fn reduce_to_map(terms: &[Term]) -> BTreeMap<ComposableTerm, Exponent> {
     terms
         .iter()
         .map(|term| {
@@ -74,7 +78,7 @@ fn reduce_to_map(terms: &[Term]) -> BTreeMap<ComposableTerm, i32> {
             )
         })
         .fold(
-            BTreeMap::<ComposableTerm, i32>::new(),
+            BTreeMap::<ComposableTerm, Exponent>::new(),
             |mut map, (key, exponent)| {
                 let _ = map
                     .entry(key)


### PR DESCRIPTION
These changes will just make it easier if/when we change what types a factor or exponent can be. (ex. In practice, it doesn't make sense to use an exponent of, what, >4?? ...in which case using an `i8` should suffice in the future).