### PR TITLE
NAUM-5 Add Term::as_cow_str()

### DIFF
--- a/crates/api/CHANGELOG.md
+++ b/crates/api/CHANGELOG.md
@@ -24,7 +24,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `measurement!()` macro for wrapping `Measurement::try_new().unwrap()`.
 - Added `crate::term::Factor` type alias for `u32`.
 - Added `crate::term::Exponent` type alias for `i32`.
-- Added `crate::Term::as_str()`.
+- NAUM-5: Added `crate::Term::as_cow_str()`.
 - (Internal) Added constants for many but not all internal `Definition`s.
 
 ### Changed
@@ -46,7 +46,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `term`
   - `ucum_symbol`
 - (Internal) Moved `crate::parser` to `crate::unit::parser`.
-- (Internal) `Display` implementation for `Unit` now uses `Term::as_str()` logic.
+- NAUM-5: (Internal) `Display` implementation for `Unit` now uses `Term::as_cow_str()` logic.
 
 ### Deprecated
 

--- a/crates/api/CHANGELOG.md
+++ b/crates/api/CHANGELOG.md
@@ -24,6 +24,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `measurement!()` macro for wrapping `Measurement::try_new().unwrap()`.
 - Added `crate::term::Factor` type alias for `u32`.
 - Added `crate::term::Exponent` type alias for `i32`.
+- Added `crate::Term::as_str()`.
 - (Internal) Added constants for many but not all internal `Definition`s.
 
 ### Changed
@@ -45,6 +46,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `term`
   - `ucum_symbol`
 - (Internal) Moved `crate::parser` to `crate::unit::parser`.
+- (Internal) `Display` implementation for `Unit` now uses `Term::as_str()` logic.
 
 ### Deprecated
 

--- a/crates/api/src/composition.rs
+++ b/crates/api/src/composition.rs
@@ -484,13 +484,13 @@ mod tests {
     fn validate_insert() {
         let mut composition = Composition::default();
         composition.insert(Dimension::Mass, 3);
-        assert_eq!(composition.to_string().as_str(), "M3");
+        assert_eq!(composition.to_string(), "M3");
 
         composition.insert(Dimension::Mass, 3);
-        assert_eq!(composition.to_string().as_str(), "M6");
+        assert_eq!(composition.to_string(), "M6");
 
         composition.insert(Dimension::Mass, -6);
-        assert_eq!(composition.to_string().as_str(), "");
+        assert_eq!(composition.to_string(), "");
 
         let mut composition = Composition::default();
         composition.insert(Dimension::Mass, -1);
@@ -500,10 +500,7 @@ mod tests {
         composition.insert(Dimension::Length, -5);
         composition.insert(Dimension::PlaneAngle, -6);
         composition.insert(Dimension::LuminousIntensity, -7);
-        assert_eq!(
-            composition.to_string().as_str(),
-            "Q-3.L-5.F-7.M-1.A-6.C-2.T-4"
-        );
+        assert_eq!(composition.to_string(), "Q-3.L-5.F-7.M-1.A-6.C-2.T-4");
     }
 
     #[test]

--- a/crates/api/src/term.rs
+++ b/crates/api/src/term.rs
@@ -9,6 +9,8 @@ mod partial_eq;
 mod reducible;
 mod ucum_unit;
 
+use std::borrow::Cow;
+
 use crate::{Atom, Prefix};
 
 pub const UNITY: Term = {
@@ -130,6 +132,79 @@ impl Term {
     pub fn factor_as_u32(&self) -> Factor {
         self.factor.unwrap_or(1)
     }
+
+    /// Depending on the `Term`, its string representation could be anywhere from a `&'static str`
+    /// to a combination of all of its fields as a `String`. For those former cases, we want to
+    /// allow borrowing the `&'static str` to save on allocations.
+    ///
+    #[must_use]
+    pub fn as_cow_str(&self) -> Cow<'_, str> {
+        use crate::UcumSymbol;
+
+        if self.is_unity() && self.annotation.is_none() {
+            return Cow::Borrowed("1");
+        };
+
+        match (
+            self.factor,
+            self.prefix,
+            self.atom,
+            self.exponent,
+            self.annotation.as_deref(),
+        ) {
+            (None, None, None, None, None) => Cow::Borrowed(""),
+            (None | Some(1), None, None, None | Some(1), Some(ann)) => {
+                Cow::Owned(format!("{{{ann}}}"))
+            }
+            (None, None, Some(atom), None | Some(1), None) => Cow::Borrowed(atom.primary_code()),
+            (None, None, Some(atom), None | Some(1), Some(ann)) => {
+                Cow::Owned(format!("{atom}{{{ann}}}"))
+            }
+            (None, None, Some(atom), Some(exp), None) => Cow::Owned(format!("{atom}{exp}")),
+            (None, None, Some(atom), Some(exp), Some(ann)) => {
+                Cow::Owned(format!("{atom}{exp}{{{ann}}}"))
+            }
+            (None, Some(prefix), Some(atom), None | Some(1), None) => {
+                Cow::Owned(format!("{prefix}{atom}"))
+            }
+            (None, Some(prefix), Some(atom), None | Some(1), Some(ann)) => {
+                Cow::Owned(format!("{prefix}{atom}{{{ann}}}"))
+            }
+            (None, Some(prefix), Some(atom), Some(exp), None) => {
+                Cow::Owned(format!("{prefix}{atom}{exp}"))
+            }
+            (None, Some(prefix), Some(atom), Some(exp), Some(ann)) => {
+                Cow::Owned(format!("{prefix}{atom}{exp}{{{ann}}}"))
+            }
+            (Some(factor), None, None, None, None) => Cow::Owned(factor.to_string()),
+            (Some(factor), None, None, None, Some(ann)) => Cow::Owned(format!("{factor}{{{ann}}}")),
+            (Some(factor), None, Some(atom), None | Some(1), None) => {
+                Cow::Owned(format!("{factor}{atom}"))
+            }
+            (Some(factor), None, Some(atom), None | Some(1), Some(ann)) => {
+                Cow::Owned(format!("{factor}{atom}{{{ann}}}"))
+            }
+            (Some(factor), None, Some(atom), Some(exp), None) => {
+                Cow::Owned(format!("{factor}{atom}{exp}"))
+            }
+            (Some(factor), None, Some(atom), Some(exp), Some(ann)) => {
+                Cow::Owned(format!("{factor}{atom}{exp}{{{ann}}}"))
+            }
+            (Some(factor), Some(prefix), Some(atom), None | Some(1), None) => {
+                Cow::Owned(format!("{factor}{prefix}{atom}"))
+            }
+            (Some(factor), Some(prefix), Some(atom), None | Some(1), Some(ann)) => {
+                Cow::Owned(format!("{factor}{prefix}{atom}{{{ann}}}"))
+            }
+            (Some(factor), Some(prefix), Some(atom), Some(exp), None) => {
+                Cow::Owned(format!("{factor}{prefix}{atom}{exp}"))
+            }
+            (Some(factor), Some(prefix), Some(atom), Some(exp), Some(ann)) => {
+                Cow::Owned(format!("{factor}{prefix}{atom}{exp}{{{ann}}}"))
+            }
+            _ => unreachable!("Invalid Term: {self:?}"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -139,5 +214,58 @@ mod tests {
     #[test]
     fn validate_new_unity() {
         assert_eq!(UNITY.to_string(), "1");
+    }
+
+    #[test]
+    fn as_str_test() {
+        assert_eq!(UNITY.as_cow_str(), "1");
+
+        // None, None, None, None, None
+        assert_eq!(Term::default().as_cow_str(), "");
+
+        // None | Some(1), None, None, None, Some(ann)
+        assert_eq!(term!(annotation: "hi".to_string()).as_cow_str(), "{hi}");
+        assert_eq!(
+            term!(factor: 1, annotation: "hi".to_string()).as_cow_str(),
+            "{hi}"
+        );
+
+        // None, None, Some(atom), None | Some(1), None
+        assert_eq!(term!(Meter).as_cow_str(), "m");
+        assert_eq!(term!(Meter, exponent: 1).as_cow_str(), "m");
+
+        // None, None, Some(atom), None | Some(1), Some(ann)
+        assert_eq!(
+            term!(Meter, annotation: "hi".to_string()).as_cow_str(),
+            "m{hi}"
+        );
+        assert_eq!(
+            term!(Meter, exponent: 1, annotation: "hi".to_string()).as_cow_str(),
+            "m{hi}"
+        );
+
+        assert_eq!(term!(Meter, exponent: 2).as_cow_str(), "m2");
+        assert_eq!(term!(Meter, exponent: -1).as_cow_str(), "m-1");
+
+        assert_eq!(
+            term!(Meter, exponent: 2, annotation: "hi".to_string()).as_cow_str(),
+            "m2{hi}"
+        );
+
+        assert_eq!(term!(Kilo, Meter).as_cow_str(), "km");
+
+        assert_eq!(
+            term!(Kilo, Meter, annotation: "hi".to_string()).as_cow_str(),
+            "km{hi}"
+        );
+
+        assert_eq!(
+            term!(Kilo, Meter, exponent: 1, annotation: "hi".to_string()).as_cow_str(),
+            "km{hi}"
+        );
+        assert_eq!(
+            term!(Kilo, Meter, exponent: 2, annotation: "hi".to_string()).as_cow_str(),
+            "km2{hi}"
+        );
     }
 }

--- a/crates/api/src/term/display.rs
+++ b/crates/api/src/term/display.rs
@@ -1,53 +1,10 @@
 use std::fmt;
 
-use super::{Factor, Term};
+use super::Term;
 
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", extract_term_string(self))
-    }
-}
-
-fn extract_term_string(term: &Term) -> String {
-    if term.is_unity() && term.annotation.is_none() {
-        return String::from("1");
-    };
-
-    let mut term_string = String::new();
-    extract_term_string_factor(&mut term_string, term.factor);
-    extract_term_string_atom(&mut term_string, term);
-
-    if let Some(ref annotation) = term.annotation {
-        term_string.push_str(&format!("{{{annotation}}}"));
-    }
-
-    term_string
-}
-
-fn extract_term_string_factor(term_string: &mut String, term_factor: Option<Factor>) {
-    if let Some(factor) = term_factor {
-        if factor != 1 {
-            term_string.push_str(&factor.to_string());
-        }
-    }
-}
-
-fn extract_term_string_atom(term_string: &mut String, term: &Term) {
-    if let Some(atom) = term.atom {
-        if let Some(prefix) = term.prefix {
-            term_string.push_str(&prefix.to_string());
-        }
-
-        match term.exponent {
-            Some(exponent) => {
-                if exponent == 1 {
-                    term_string.push_str(&atom.to_string());
-                } else {
-                    term_string.push_str(&format!("{atom}{exponent}"));
-                }
-            }
-            None => term_string.push_str(&atom.to_string()),
-        }
+        write!(f, "{}", self.as_cow_str())
     }
 }
 
@@ -60,7 +17,7 @@ mod tests {
             #[test]
             fn $test_name() {
                 let term = $term;
-                assert_eq!(term.to_string().as_str(), $output);
+                assert_eq!(term.to_string(), $output);
             }
         };
 
@@ -68,7 +25,7 @@ mod tests {
             #[test]
             fn $test_name() {
                 let term = term!();
-                assert_eq!(term.to_string().as_str(), $output);
+                assert_eq!(term.to_string(), $output);
             }
         };
     }

--- a/crates/api/src/term/num_traits/inv.rs
+++ b/crates/api/src/term/num_traits/inv.rs
@@ -50,7 +50,7 @@ pub(crate) fn inv_terms(terms: &mut Vec<Term>) {
 // This solves not being able to `impl Inv for Vec<Term>`.
 //
 pub(crate) fn inv_terms_into(terms: Vec<Term>) -> Vec<Term> {
-    terms.into_iter().map(num_traits::Inv::inv).collect()
+    terms.into_iter().map(Inv::inv).collect()
 }
 
 #[cfg(test)]

--- a/crates/api/src/unit.rs
+++ b/crates/api/src/unit.rs
@@ -165,6 +165,8 @@ impl Unit {
     }
 }
 
+// TODO: This is silly; remove.
+//
 impl AsRef<Self> for Unit {
     fn as_ref(&self) -> &Self {
         self

--- a/crates/api/src/unit.rs
+++ b/crates/api/src/unit.rs
@@ -135,7 +135,7 @@ impl Unit {
     /// use wise_units::Unit;
     ///
     /// let u = Unit::from_str("[acr_us].[in_i]/[acr_us]").unwrap();
-    /// assert_eq!(u.expression().as_str(), "[acr_us].[in_i]/[acr_us]");
+    /// assert_eq!(u.expression(), "[acr_us].[in_i]/[acr_us]");
     /// ```
     ///
     #[inline]
@@ -153,7 +153,7 @@ impl Unit {
     /// use wise_units::Unit;
     ///
     /// let u = Unit::from_str("[acr_us].[in_i]/[acr_us]").unwrap();
-    /// assert_eq!(u.expression_reduced().as_str(), "[in_i]");
+    /// assert_eq!(u.expression_reduced(), "[in_i]");
     /// ```
     ///
     #[inline]
@@ -205,55 +205,55 @@ mod tests {
     #[test]
     fn validate_expression_reduced() {
         let unit = Unit::from_str("m").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "m");
+        assert_eq!(unit.expression_reduced(), "m");
 
         let unit = Unit::from_str("M").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "m");
+        assert_eq!(unit.expression_reduced(), "m");
 
         let unit = Unit::from_str("km/10m").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "km/10m");
+        assert_eq!(unit.expression_reduced(), "km/10m");
 
         let unit = Unit::from_str("m-1").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "/m");
+        assert_eq!(unit.expression_reduced(), "/m");
 
         let unit = Unit::from_str("10m").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "10m");
+        assert_eq!(unit.expression_reduced(), "10m");
 
         let unit = Unit::from_str("10km").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "10km");
+        assert_eq!(unit.expression_reduced(), "10km");
 
         let unit = Unit::from_str("10km-1").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "/10km");
+        assert_eq!(unit.expression_reduced(), "/10km");
 
         let unit = Unit::from_str("km-1/m2").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "/m2.km");
+        assert_eq!(unit.expression_reduced(), "/m2.km");
 
         let unit = Unit::from_str("km/m2.cm").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "km/m2.cm");
+        assert_eq!(unit.expression_reduced(), "km/m2.cm");
 
         let unit = Unit::from_str("km-1/m2.cm").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "/m2.cm.km");
+        assert_eq!(unit.expression_reduced(), "/m2.cm.km");
 
         let unit = Unit::from_str("m/s2").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "m/s2");
+        assert_eq!(unit.expression_reduced(), "m/s2");
 
         let unit = Unit::from_str("km3/nm2").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "km3/nm2");
+        assert_eq!(unit.expression_reduced(), "km3/nm2");
 
         let unit = Unit::from_str("Kibit").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "Kibit");
+        assert_eq!(unit.expression_reduced(), "Kibit");
 
         let unit = Unit::from_str("KiBy").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "KiBy");
+        assert_eq!(unit.expression_reduced(), "KiBy");
 
         let unit = Unit::from_str("MiBy").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "MiBy");
+        assert_eq!(unit.expression_reduced(), "MiBy");
 
         let unit = Unit::from_str("GiBy").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "GiBy");
+        assert_eq!(unit.expression_reduced(), "GiBy");
 
         let unit = Unit::from_str("TiBy").unwrap();
-        assert_eq!(unit.expression_reduced().as_str(), "TiBy");
+        assert_eq!(unit.expression_reduced(), "TiBy");
     }
 
     #[cfg(feature = "cffi")]
@@ -267,7 +267,7 @@ mod tests {
             let unit = unsafe { custom_ffi::unit_init(core::ffi_string!(expression)) };
             let c_expression = unsafe { custom_ffi::get_unit_expression(unit) };
             assert_eq!(expression, unsafe {
-                ffi_common::core::string::string_from_c(c_expression)
+                core::string::string_from_c(c_expression)
             });
             unsafe { unit_ffi::unit_free(unit) };
         }

--- a/crates/api/src/unit/display.rs
+++ b/crates/api/src/unit/display.rs
@@ -1,98 +1,54 @@
+use std::{borrow::Cow, fmt};
+
 use crate::{Term, Unit};
-use std::fmt;
 
 //-----------------------------------------------------------------------------
 // impl Display
 //-----------------------------------------------------------------------------
 impl fmt::Display for Unit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", decompose(self))
+        let (numerators, denominators) = decompose(&self.terms);
+
+        write!(f, "{}", recompose(&numerators, &denominators))
     }
 }
 
-/// Turns `terms` into a `String` for display.
+/// Turns `terms` into two groups of strings: one for numerator terms, one for denominator terms.
+/// These just need to be properly jointed by dots and slashes.
 ///
-fn decompose(unit: &Unit) -> String {
-    let numerator = string_from_collection(&unit.terms, extract_numerator);
-    let denominator = string_from_collection(&unit.terms, extract_denominator);
+fn decompose(terms: &[Term]) -> (Vec<Cow<'_, str>>, Vec<String>) {
+    let mut numerators = Vec::new();
+    let mut denominators = Vec::new();
 
-    format_output(numerator, denominator)
-}
-
-fn format_output(numerator: Option<String>, denominator: Option<String>) -> String {
-    match (numerator, denominator) {
-        (Some(n), Some(d)) => [n, d].join("/"),
-        (Some(n), None) => n,
-        (None, Some(d)) => format!("/{d}"),
-        (None, None) => "1".to_string(),
-    }
-}
-
-fn string_from_collection<F>(terms: &[Term], func: F) -> Option<String>
-where
-    F: Fn(&Term) -> Option<String>,
-{
-    terms
-        .iter()
-        .filter_map(func)
-        .fold(None, |acc: Option<String>, term_string: String| match acc {
-            Some(mut a) => {
-                a.push('.');
-                a.push_str(&term_string);
-
-                Some(a)
-            }
-            None => Some(term_string),
-        })
-}
-
-/// Specifically for use with `filter_map()`, this returns `None` if the `Term` is not positive.
-///
-fn extract_numerator(term: &Term) -> Option<String> {
-    if !term.has_value() || !term.exponent_is_positive() {
-        return None;
-    }
-
-    Some(term.to_string())
-}
-
-/// Specifically for use with `filter_map()`, this returns `None` if the `Term` is not negative.
-///
-fn extract_denominator(term: &Term) -> Option<String> {
-    if !term.has_value() || !term.exponent_is_negative() {
-        return None;
-    }
-
-    let mut term_string = String::new();
-
-    term.factor_and_is_not_one(|factor| term_string.push_str(&factor.to_string()));
-
-    extract_denominator_atom(term, &mut term_string);
-
-    if let Some(ref annotation) = term.annotation {
-        term_string.push_str(&format!("{{{annotation}}}"));
-    }
-
-    Some(term_string)
-}
-
-fn extract_denominator_atom(term: &Term, term_string: &mut String) {
-    if let Some(atom) = term.atom {
-        if let Some(prefix) = term.prefix {
-            term_string.push_str(&prefix.to_string());
-        }
-
+    for term in terms {
         if let Some(exponent) = term.exponent {
-            let ex_abs = exponent.abs();
-
-            if ex_abs == 1 {
-                term_string.push_str(&atom.to_string());
+            if exponent.is_positive() {
+                numerators.push(term.as_cow_str());
             } else {
-                term_string.push_str(&format!("{atom}{ex_abs}"));
+                let mut positive_exponent_term = term.clone();
+                positive_exponent_term.exponent = Some(exponent.abs());
+
+                denominators.push(positive_exponent_term.to_string());
             }
         } else {
-            term_string.push_str(&atom.to_string());
+            numerators.push(term.as_cow_str());
         }
+    }
+
+    (numerators, denominators)
+}
+
+fn recompose<'a>(numerators: &[Cow<'a, str>], denominators: &[String]) -> Cow<'a, str> {
+    match (numerators.len(), denominators.len()) {
+        (0, 0) => Cow::Borrowed("1"),
+        (0, _) => Cow::Owned(format!("/{}", denominators.join("."))),
+        (1, 0) => numerators[0].clone(),
+        (_, 0) => Cow::Owned(numerators.join(".")),
+        (_, _) => Cow::Owned(format!(
+            "{}/{}",
+            numerators.join("."),
+            denominators.join("."),
+        )),
     }
 }
 
@@ -104,54 +60,60 @@ mod tests {
     #[test]
     fn validate_display() {
         let unit = Unit::from_str("1").unwrap();
-        assert_eq!(unit.to_string().as_str(), "1");
+        assert_eq!(unit.to_string(), "1");
 
         let unit = Unit::from_str("m").unwrap();
-        assert_eq!(unit.to_string().as_str(), "m");
+        assert_eq!(unit.to_string(), "m");
 
         let unit = Unit::from_str("M").unwrap();
-        assert_eq!(unit.to_string().as_str(), "m");
+        assert_eq!(unit.to_string(), "m");
 
         let unit = Unit::from_str("{stuff}").unwrap();
-        assert_eq!(unit.to_string().as_str(), "{stuff}");
+        assert_eq!(unit.to_string(), "{stuff}");
+
+        let unit = Unit::from_str("/{stuff}").unwrap();
+        assert_eq!(unit.to_string(), "/{stuff}");
 
         let unit = Unit::from_str("m{stuff}").unwrap();
-        assert_eq!(unit.to_string().as_str(), "m{stuff}");
+        assert_eq!(unit.to_string(), "m{stuff}");
 
         let unit = Unit::from_str("km/10m").unwrap();
-        assert_eq!(unit.to_string().as_str(), "km/10m");
+        assert_eq!(unit.to_string(), "km/10m");
 
         let unit = Unit::from_str("m-1").unwrap();
-        assert_eq!(unit.to_string().as_str(), "/m");
+        assert_eq!(unit.to_string(), "/m");
 
         let unit = Unit::from_str("m-1{stuff}").unwrap();
-        assert_eq!(unit.to_string().as_str(), "/m{stuff}");
+        assert_eq!(unit.to_string(), "/m{stuff}");
 
         let unit = Unit::from_str("10m").unwrap();
-        assert_eq!(unit.to_string().as_str(), "10m");
+        assert_eq!(unit.to_string(), "10m");
 
         let unit = Unit::from_str("10km").unwrap();
-        assert_eq!(unit.to_string().as_str(), "10km");
+        assert_eq!(unit.to_string(), "10km");
 
         let unit = Unit::from_str("10km-1").unwrap();
-        assert_eq!(unit.to_string().as_str(), "/10km");
+        assert_eq!(unit.to_string(), "/10km");
 
         let unit = Unit::from_str("km-1/m2").unwrap();
-        assert_eq!(unit.to_string().as_str(), "/km.m2");
+        assert_eq!(unit.to_string(), "/km.m2");
 
         let unit = Unit::from_str("km/m2.cm").unwrap();
-        assert_eq!(unit.to_string().as_str(), "km/m2.cm");
+        assert_eq!(unit.to_string(), "km/m2.cm");
 
         let unit = Unit::from_str("km-1/m2.cm").unwrap();
-        assert_eq!(unit.to_string().as_str(), "/km.m2.cm");
+        assert_eq!(unit.to_string(), "/km.m2.cm");
 
         let unit = Unit::from_str("m/s2").unwrap();
-        assert_eq!(unit.to_string().as_str(), "m/s2");
+        assert_eq!(unit.to_string(), "m/s2");
 
         let unit = Unit::from_str("km3/nm2").unwrap();
-        assert_eq!(unit.to_string().as_str(), "km3/nm2");
+        assert_eq!(unit.to_string(), "km3/nm2");
 
         let unit = Unit::from_str("km3{foo}/nm2{bar}").unwrap();
-        assert_eq!(unit.to_string().as_str(), "km3{foo}/nm2{bar}");
+        assert_eq!(unit.to_string(), "km3{foo}/nm2{bar}");
+
+        let unit = Unit::from_str("{foo}/{bar}").unwrap();
+        assert_eq!(unit.to_string(), "{foo}/{bar}");
     }
 }


### PR DESCRIPTION
Adds `Term::as_cow_str()`, which basically allows for returning `&str`s when possible and `String`s when formatting is required. Also updates places that use `term.to_string()` to use this--notably in the `Display` impl for `Unit` (which was duplicating much of the old/same logic from `Term`).

- **NAUM-5 Add Term::as_str()**
- **Add TODO for later**
