### PR TITLE
NAUM-6 Add v2::ToFraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ This feature is disabled by default. To enable it:
 wise_units = { version = "0.22", features = ["serde"] }
 ```
 
+### Feature `v2`
+
+The `v2` feature makes some new traits available--traits that are "fixed" versions of existing
+traits. Putting these behind this feature flag allows us to try out these new traits in downstream
+crates before switching them to be the main traits in `wise_units`.
+
 ## Examples
 
 A `Measurement` is made up of some quantifier, the `value`, and the unit of measure,

--- a/crates/api/CHANGELOG.md
+++ b/crates/api/CHANGELOG.md
@@ -51,6 +51,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `ucum_symbol`
 - (Internal) Moved `crate::parser` to `crate::unit::parser`.
 - NAUM-5: (Internal) `Display` implementation for `Unit` now uses `Term::as_cow_str()` logic.
+- NAUM-6: Updated `AsFraction::as_fraction()` implementation to iterate through `Term`s once instead
+  of twice for building the numerator and denominator.
 
 ### Deprecated
 

--- a/crates/api/CHANGELOG.md
+++ b/crates/api/CHANGELOG.md
@@ -26,6 +26,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - NAUM-6
   - Add new `"v2"` feature.
   - Add `v2::convert::ToFraction` trait.
+  - Implemented `v2::convert::ToFraction` trait for `Unit`, `Measurement`.
 - Added `Unit::into_terms()` for cases where you only need the `Term`s of the `Unit`.
 - Added `unit` constant: `UNITY`
 - Added `term` constants: `UNITY`, `UNITY_ARRAY`, and `UNITY_ARRAY_REF`.

--- a/crates/api/CHANGELOG.md
+++ b/crates/api/CHANGELOG.md
@@ -18,11 +18,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - PLCC-287: `impl num_traits::NumCast for Measurement`.
 - PLCC-287: `impl num_traits::Pow<i32> for Measurement`, `Unit`, `Term`.
 - PLCC-287: `impl std::ops::Neg for Measurement`.
-- NAUM-5: Added `crate::Term::as_cow_str()`.
 - NAUM-4: Derive `PartialOrd` for `Composition`
 - NAUM-4: `impl From<Dimension> for Composition`
 - NAUM-4: Derive `Hash` for `Property`
 - NAUM-4: `impl PartialOrd for Term`
+- NAUM-5: Added `crate::Term::as_cow_str()`.
+- NAUM-6
+  - Add new `"v2"` feature.
+  - Add `v2::convert::ToFraction` trait.
 - Added `Unit::into_terms()` for cases where you only need the `Term`s of the `Unit`.
 - Added `unit` constant: `UNITY`
 - Added `term` constants: `UNITY`, `UNITY_ARRAY`, and `UNITY_ARRAY_REF`.

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -20,7 +20,6 @@ thiserror = "1.0"
 [dev-dependencies]
 bincode = "1.3"
 criterion = "0.5"
-lazy_static.workspace = true
 rmp-serde = "1.0"
 serde_json = "1.0"
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -30,6 +30,8 @@ default = []
 # additional ffi module will be generated for each supported resource type.
 cffi = ["ffi_common"]
 
+v2 = []
+
 [[bench]]
 name = "measurements_benchmarks"
 harness = false

--- a/crates/api/src/composition.rs
+++ b/crates/api/src/composition.rs
@@ -356,7 +356,7 @@ fn push_display_expression(
 // ╰──────────╯
 /// Used for combining two `Compositions`.
 ///
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::suspicious_arithmetic_impl))]
+#[allow(clippy::suspicious_arithmetic_impl)]
 impl Mul for Composition {
     type Output = Self;
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -21,29 +21,32 @@
 #[macro_use]
 mod macros;
 
-pub(crate) mod annotation_composition;
 pub mod as_fraction;
 pub mod atom;
 pub mod classification;
-mod composable;
 pub mod composition;
 pub mod convertible;
-mod dimension;
 pub mod error;
 pub mod field_eq;
 pub mod invert;
 pub mod is_compatible_with;
 pub mod measurement;
-mod prefix;
 pub mod property;
 pub mod reduce;
-pub(crate) mod term;
-mod ucum_symbol;
 pub mod unit;
+#[cfg(feature = "v2")]
+pub mod v2;
 
+pub(crate) mod annotation_composition;
+pub(crate) mod term;
+
+mod composable;
+mod dimension;
+mod prefix;
 mod reducible;
 #[cfg(test)]
 mod testing;
+mod ucum_symbol;
 mod ucum_unit;
 
 pub use crate::{

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -42,6 +42,8 @@ mod ucum_symbol;
 pub mod unit;
 
 mod reducible;
+#[cfg(test)]
+mod testing;
 mod ucum_unit;
 
 pub use crate::{

--- a/crates/api/src/macros.rs
+++ b/crates/api/src/macros.rs
@@ -69,7 +69,7 @@ macro_rules! terms {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Term, Atom, Prefix};
+    use crate::{Atom, Prefix, Term};
 
     #[test]
     fn validate_term_macro() {

--- a/crates/api/src/measurement.rs
+++ b/crates/api/src/measurement.rs
@@ -12,6 +12,8 @@ mod partial_ord;
 mod reducible;
 mod to_reduced;
 mod ucum_unit;
+#[cfg(feature = "v2")]
+mod v2;
 
 use crate::{reducible::Reducible, ucum_unit::UcumUnit, unit::Unit};
 

--- a/crates/api/src/measurement/v2.rs
+++ b/crates/api/src/measurement/v2.rs
@@ -1,0 +1,1 @@
+mod convert;

--- a/crates/api/src/measurement/v2/convert.rs
+++ b/crates/api/src/measurement/v2/convert.rs
@@ -1,0 +1,99 @@
+use crate::{unit, v2::convert::ToFraction, Measurement, Unit};
+
+impl ToFraction<Self, Option<Unit>> for Measurement {
+    fn to_fraction(&self) -> (Self, Option<Unit>) {
+        let unit_parts = self.unit.to_fraction();
+
+        (
+            Self {
+                value: self.value,
+                unit: unit_parts.0.unwrap_or(unit::UNITY),
+            },
+            unit_parts.1,
+        )
+    }
+
+    fn to_numerator(&self) -> Self {
+        Self {
+            value: self.value,
+            unit: self.unit.to_numerator().unwrap_or(unit::UNITY),
+        }
+    }
+
+    fn to_denominator(&self) -> Option<Unit> {
+        self.unit.to_denominator()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        testing::const_units::{GRAM_METER, METER, METER_PER_SECOND, PER_SECOND, SECOND},
+        unit::UNITY,
+        Measurement,
+    };
+
+    use super::*;
+
+    macro_rules! validate_fraction_parts {
+        (
+            $measurement:expr,
+            expected_numerator => $expected_numerator:expr,
+            expected_denominator => $expected_denominator:expr
+        ) => {
+            let fraction = $measurement.to_fraction();
+            assert_eq!(&fraction.0, &$expected_numerator);
+            assert_eq!(fraction.1, $expected_denominator);
+
+            let numerator = $measurement.to_numerator();
+            assert_eq!(numerator, $expected_numerator);
+
+            let denominator = $measurement.to_denominator();
+            assert_eq!(denominator, $expected_denominator);
+        };
+    }
+
+    #[test]
+    fn validate_one_numerator_term() {
+        let measurement = Measurement::new(42.0, METER);
+
+        validate_fraction_parts!(
+            measurement,
+            expected_numerator => measurement,
+            expected_denominator => None
+        );
+    }
+
+    #[test]
+    fn validate_two_numerator_terms() {
+        let measurement = Measurement::new(42.0, GRAM_METER);
+
+        validate_fraction_parts!(
+            measurement,
+            expected_numerator => measurement,
+            expected_denominator => None
+        );
+    }
+
+    #[test]
+    fn validate_one_numerator_term_one_denominator_term() {
+        let measurement = Measurement::new(42.0, METER_PER_SECOND);
+
+        validate_fraction_parts!(
+            measurement,
+            expected_numerator => Measurement::new(42.0, METER),
+            expected_denominator => Some(SECOND)
+        );
+    }
+
+    #[test]
+    fn validate_one_denominator_term() {
+        let measurement = Measurement::new(42.0, PER_SECOND);
+
+        validate_fraction_parts!(
+            measurement,
+            expected_numerator => Measurement::new(42.0, UNITY),
+            expected_denominator => Some(SECOND)
+        );
+    }
+}

--- a/crates/api/src/testing.rs
+++ b/crates/api/src/testing.rs
@@ -1,0 +1,112 @@
+pub(crate) mod const_units {
+    use std::borrow::Cow;
+
+    use crate::{Atom, Prefix, Term, Unit};
+
+    pub(crate) const METER: Unit = Unit {
+        terms: Cow::Borrowed(&[Term {
+            factor: None,
+            prefix: None,
+            atom: Some(Atom::Meter),
+            exponent: None,
+            annotation: None,
+        }]),
+    };
+
+    pub(crate) const KILOMETER: Unit = Unit {
+        terms: Cow::Borrowed(&[Term {
+            factor: None,
+            prefix: Some(Prefix::Kilo),
+            atom: Some(Atom::Meter),
+            exponent: None,
+            annotation: None,
+        }]),
+    };
+
+    pub(crate) const GRAM_METER: Unit = Unit {
+        terms: Cow::Borrowed(&[
+            Term {
+                factor: None,
+                prefix: None,
+                atom: Some(Atom::Gram),
+                exponent: None,
+                annotation: None,
+            },
+            Term {
+                factor: None,
+                prefix: None,
+                atom: Some(Atom::Meter),
+                exponent: None,
+                annotation: None,
+            },
+        ]),
+    };
+
+    pub(crate) const PER_GRAM_METER: Unit = Unit {
+        terms: Cow::Borrowed(&[
+            Term {
+                factor: None,
+                prefix: None,
+                atom: Some(Atom::Gram),
+                exponent: Some(-1),
+                annotation: None,
+            },
+            Term {
+                factor: None,
+                prefix: None,
+                atom: Some(Atom::Meter),
+                exponent: Some(-1),
+                annotation: None,
+            },
+        ]),
+    };
+
+    pub(crate) const SECOND: Unit = Unit {
+        terms: Cow::Borrowed(&[Term {
+            factor: None,
+            prefix: None,
+            atom: Some(Atom::Second),
+            exponent: None,
+            annotation: None,
+        }]),
+    };
+
+    pub(crate) const PER_SECOND: Unit = Unit {
+        terms: Cow::Borrowed(&[Term {
+            factor: None,
+            prefix: None,
+            atom: Some(Atom::Second),
+            exponent: Some(-1),
+            annotation: None,
+        }]),
+    };
+
+    pub(crate) const METER_PER_SECOND: Unit = Unit {
+        terms: Cow::Borrowed(&[
+            Term {
+                factor: None,
+                prefix: None,
+                atom: Some(Atom::Meter),
+                exponent: None,
+                annotation: None,
+            },
+            Term {
+                factor: None,
+                prefix: None,
+                atom: Some(Atom::Second),
+                exponent: Some(-1),
+                annotation: None,
+            },
+        ]),
+    };
+
+    pub(crate) const ACRE: Unit = Unit {
+        terms: Cow::Borrowed(&[Term {
+            factor: None,
+            prefix: None,
+            atom: Some(Atom::AcreUS),
+            exponent: None,
+            annotation: None,
+        }]),
+    };
+}

--- a/crates/api/src/unit.rs
+++ b/crates/api/src/unit.rs
@@ -48,7 +48,7 @@ pub const UNITY: Unit = Unit {
 )]
 #[derive(Clone, Debug)]
 pub struct Unit {
-    terms: Cow<'static, [Term]>,
+    pub(crate) terms: Cow<'static, [Term]>,
 }
 
 /// A `Unit` is the piece of data that represents a *valid* UCUM unit or

--- a/crates/api/src/unit.rs
+++ b/crates/api/src/unit.rs
@@ -14,6 +14,8 @@ mod partial_ord;
 mod reducible;
 mod term_reducing;
 mod to_reduced;
+#[cfg(feature = "v2")]
+mod v2;
 
 #[allow(clippy::module_name_repetitions)]
 mod ucum_unit;

--- a/crates/api/src/unit/as_fraction.rs
+++ b/crates/api/src/unit/as_fraction.rs
@@ -6,6 +6,43 @@ impl AsFraction for Unit {
     type Numerator = Option<Self>;
     type Denominator = Option<Self>;
 
+    fn as_fraction(&self) -> (Self::Numerator, Self::Denominator) {
+        use crate::Term;
+
+        #[derive(Default)]
+        struct Parts {
+            numerators: Vec<Term>,
+            denominators: Vec<Term>,
+        }
+
+        let mut parts = Parts::default();
+
+        for term in &*self.terms {
+            match term.exponent {
+                Some(e) => {
+                    if e.is_negative() {
+                        parts.denominators.push(term.inv());
+                    } else {
+                        parts.numerators.push(term.clone());
+                    }
+                }
+                None => {
+                    parts.numerators.push(term.clone());
+                }
+            }
+        }
+
+        match (parts.numerators.is_empty(), parts.denominators.is_empty()) {
+            (true, true) => (None, None),
+            (true, _) => (None, Some(Self::new(parts.denominators))),
+            (_, true) => (Some(Self::new(parts.numerators)), None),
+            (_, _) => (
+                Some(Self::new(parts.numerators)),
+                Some(Self::new(parts.denominators)),
+            ),
+        }
+    }
+
     #[inline]
     fn numerator(&self) -> Self::Numerator {
         let positive_terms: Vec<Term> = self

--- a/crates/api/src/unit/as_fraction.rs
+++ b/crates/api/src/unit/as_fraction.rs
@@ -43,21 +43,17 @@ impl AsFraction for Unit {
 
 #[cfg(test)]
 mod tests {
-    use super::Unit;
     use std::str::FromStr;
 
-    lazy_static::lazy_static! {
-        static ref METER: Unit = Unit::from_str("m").unwrap();
-        static ref SECOND: Unit = Unit::from_str("s").unwrap();
-        static ref GRAM_METER: Unit = Unit::from_str("g.m").unwrap();
-        static ref METER_PER_SECOND: Unit = Unit::from_str("m/s").unwrap();
-        static ref PER_SECOND: Unit = Unit::from_str("/s").unwrap();
-        static ref PER_GRAM_METER: Unit = Unit::from_str("/g.m").unwrap();
-    }
+    use crate::{
+        as_fraction::AsFraction,
+        testing::const_units::{GRAM_METER, METER, METER_PER_SECOND, PER_SECOND},
+    };
+
+    use super::Unit;
 
     #[test]
     fn validate_as_fraction() {
-        use crate::as_fraction::AsFraction;
         let (num, den) = Unit::from_str("m/s").unwrap().as_fraction();
 
         assert!(num.is_some());
@@ -66,24 +62,23 @@ mod tests {
 
     mod numerator {
         use super::*;
-        use crate::as_fraction::AsFraction;
 
         #[test]
         fn validate_one_numerator_term() {
             let numerator = METER.numerator().unwrap();
-            assert_eq!(&numerator, &*METER);
+            assert_eq!(numerator, METER);
         }
 
         #[test]
         fn validate_two_numerator_terms() {
             let numerator = GRAM_METER.numerator().unwrap();
-            assert_eq!(&numerator, &*GRAM_METER);
+            assert_eq!(numerator, GRAM_METER);
         }
 
         #[test]
         fn validate_one_numerator_term_one_denominator_term() {
             let numerator = METER_PER_SECOND.numerator().unwrap();
-            assert_eq!(&numerator, &*METER);
+            assert_eq!(numerator, METER);
         }
 
         #[test]
@@ -94,8 +89,9 @@ mod tests {
     }
 
     mod denominator {
+        use crate::testing::const_units::{PER_GRAM_METER, SECOND};
+
         use super::*;
-        use crate::as_fraction::AsFraction;
 
         #[test]
         fn validate_one_numerator_term() {
@@ -112,19 +108,19 @@ mod tests {
         #[test]
         fn validate_one_numerator_term_one_denominator_term() {
             let denominator = METER_PER_SECOND.denominator().unwrap();
-            assert_eq!(&denominator, &*SECOND);
+            assert_eq!(denominator, SECOND);
         }
 
         #[test]
         fn validate_one_denominator_term() {
             let denominator = PER_SECOND.denominator().unwrap();
-            assert_eq!(&denominator, &*SECOND);
+            assert_eq!(denominator, SECOND);
         }
 
         #[test]
         fn validate_two_denominator_terms() {
             let denominator = PER_GRAM_METER.denominator().unwrap();
-            assert_eq!(&denominator, &*GRAM_METER);
+            assert_eq!(denominator, GRAM_METER);
         }
     }
 }

--- a/crates/api/src/unit/ops.rs
+++ b/crates/api/src/unit/ops.rs
@@ -117,37 +117,39 @@ impl<'a> Mul<Unit> for &'a Unit {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::str::FromStr;
 
-    lazy_static::lazy_static! {
-        static ref ACRE: Unit = Unit::from_str("[acr_us]").unwrap();
-        static ref METER: Unit = Unit::from_str("m").unwrap();
-        static ref KILOMETER: Unit = Unit::from_str("km").unwrap();
-        static ref SEED: Unit = Unit::from_str("{seed}").unwrap();
-        static ref UNITY: Unit = Unit::from_str("1").unwrap();
+    use crate::{
+        testing::const_units::{ACRE, KILOMETER, METER},
+        unit::UNITY,
+    };
+
+    use super::*;
+
+    fn seed() -> Unit {
+        Unit::from_str("{seed}").unwrap()
     }
 
     #[test]
     #[allow(clippy::eq_op)]
     fn validate_div() {
         let expected = Unit::from_str("m/km").unwrap();
-        assert_eq!(&*METER / &*KILOMETER, expected);
+        assert_eq!(METER / KILOMETER, expected);
 
         let unit = Unit::from_str("10m").unwrap();
         let other = Unit::from_str("20m").unwrap();
         let expected = Unit::from_str("10m/20m").unwrap();
         assert_eq!(unit / other, expected);
 
-        assert_eq!(&*SEED / &*SEED, *UNITY);
-        assert_eq!(&*UNITY / &*SEED, Unit::from_str("/{seed}").unwrap());
-        assert_eq!(&*SEED / &*ACRE, Unit::from_str("{seed}/[acr_us]").unwrap());
+        assert_eq!(seed() / seed(), UNITY);
+        assert_eq!(UNITY / seed(), Unit::from_str("/{seed}").unwrap());
+        assert_eq!(seed() / ACRE, Unit::from_str("{seed}/[acr_us]").unwrap());
     }
 
     #[test]
     fn validate_mul() {
         let expected = Unit::from_str("m.km").unwrap();
-        assert_eq!(&*METER * &*KILOMETER, expected);
+        assert_eq!(METER * KILOMETER, expected);
 
         let unit = Unit::from_str("10m").unwrap();
         let other = Unit::from_str("20m").unwrap();
@@ -155,9 +157,9 @@ mod tests {
         assert_eq!(unit * other, expected);
 
         let per_seed = Unit::from_str("/{seed}").unwrap();
-        assert_eq!(&*SEED * &per_seed, *UNITY);
+        assert_eq!(seed() * &per_seed, UNITY);
 
         let seed_per_acre = Unit::from_str("{seed}/[acr_us]").unwrap();
-        assert_eq!(seed_per_acre * &*ACRE, *SEED);
+        assert_eq!(seed_per_acre * ACRE, seed());
     }
 }

--- a/crates/api/src/unit/v2.rs
+++ b/crates/api/src/unit/v2.rs
@@ -1,0 +1,1 @@
+mod convert;

--- a/crates/api/src/unit/v2/convert.rs
+++ b/crates/api/src/unit/v2/convert.rs
@@ -1,0 +1,102 @@
+use crate::{as_fraction::AsFraction, v2::convert::ToFraction, Unit};
+
+impl ToFraction for Unit {
+    fn to_fraction(&self) -> (Option<Self>, Option<Self>) {
+        // Just delegate to the old trait impl for now.
+        AsFraction::as_fraction(self)
+    }
+
+    fn to_numerator(&self) -> Option<Self> {
+        // Just delegate to the old trait impl for now.
+        AsFraction::numerator(self)
+    }
+
+    fn to_denominator(&self) -> Option<Self> {
+        // Just delegate to the old trait impl for now.
+        AsFraction::denominator(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::{
+        testing::const_units::{GRAM_METER, METER, METER_PER_SECOND, PER_SECOND},
+        Unit,
+    };
+
+    use super::ToFraction;
+
+    #[test]
+    fn validate_to_fraction() {
+        let (num, den) = Unit::from_str("m/s").unwrap().to_fraction();
+
+        assert!(num.is_some());
+        assert!(den.is_some());
+    }
+
+    mod numerator {
+        use super::*;
+
+        #[test]
+        fn validate_one_numerator_term() {
+            let numerator = METER.to_numerator().unwrap();
+            assert_eq!(numerator, METER);
+        }
+
+        #[test]
+        fn validate_two_numerator_terms() {
+            let numerator = GRAM_METER.to_numerator().unwrap();
+            assert_eq!(numerator, GRAM_METER);
+        }
+
+        #[test]
+        fn validate_one_numerator_term_one_denominator_term() {
+            let numerator = METER_PER_SECOND.to_numerator().unwrap();
+            assert_eq!(numerator, METER);
+        }
+
+        #[test]
+        fn validate_one_denominator_term() {
+            let numerator = PER_SECOND.to_numerator();
+            assert!(numerator.is_none());
+        }
+    }
+
+    mod denominator {
+        use crate::testing::const_units::{PER_GRAM_METER, SECOND};
+
+        use super::*;
+
+        #[test]
+        fn validate_one_numerator_term() {
+            let denominator = METER.to_denominator();
+            assert!(denominator.is_none());
+        }
+
+        #[test]
+        fn validate_two_numerator_terms() {
+            let denominator = GRAM_METER.to_denominator();
+            assert!(denominator.is_none());
+        }
+
+        #[test]
+        fn validate_one_numerator_term_one_denominator_term() {
+            let denominator = METER_PER_SECOND.to_denominator().unwrap();
+            assert_eq!(denominator, SECOND);
+        }
+
+        #[test]
+        fn validate_one_denominator_term() {
+            let denominator = PER_SECOND.to_denominator().unwrap();
+            assert_eq!(denominator, SECOND);
+        }
+
+        #[test]
+        fn validate_two_denominator_terms() {
+            let denominator = PER_GRAM_METER.to_denominator().unwrap();
+            assert_eq!(denominator, GRAM_METER);
+        }
+    }
+}

--- a/crates/api/src/v2.rs
+++ b/crates/api/src/v2.rs
@@ -1,0 +1,1 @@
+pub mod convert;

--- a/crates/api/src/v2/convert.rs
+++ b/crates/api/src/v2/convert.rs
@@ -1,0 +1,11 @@
+/// This is the next version of `AsFraction`, which was incorrectly named, according to Rust
+/// API guidelines. The difference with this trait is that a) you can specify the output type for
+/// the `to_fraction()` call, letting wrapper crates use this trait (since other types may not
+/// easily be able to convert from `(Self::Numerator, Self::Denominator)`).
+///
+pub trait ToFraction<N = Option<Self>, D = Option<Self>, F = (N, D)> {
+    fn to_fraction(&self) -> F;
+
+    fn to_numerator(&self) -> N;
+    fn to_denominator(&self) -> D;
+}


### PR DESCRIPTION
This is what I think I'd like to use to replace the existing AsFraction trait, which is problematic (see the related ticket). I

- Added a `v2` feature flag
- Added a `v2::convert` module
- Added the `v2::convert::ToFraction` trait
- Implemented the trait for `Unit` and `Measurement` (there was no `AsFraction` trait for `Measurement` before)
- Fixed the `AsFraction::as_fraction()` implementation to only iterate through all nested `Term`s once (to collect numerators and denominators along the way) instead of iterating once for numerators and once for denominators.
- Got rid of `lazy_static` as a dep (was only used in 2 sets of tests)