### PR TITLE
NAUM-8 v2::ToReduced, TryToReduced

### DIFF
--- a/crates/api/CHANGELOG.md
+++ b/crates/api/CHANGELOG.md
@@ -29,6 +29,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - Implemented `v2::convert::ToFraction` trait for `Unit`, `Measurement`.
 - NAUM-7: Added traits `v2::convert::ConvertTo<U, O>` and `v2::convert::TryConvertTo<U, O>` and
   implemented for `Measurement`.
+- NAUM-8: Added traits `v2::convert::ToReduced<T>` and `TryToReduced<T>`, and implemented for `Unit`
+  and `Measurement`, respectively.
 - Added `Unit::into_terms()` for cases where you only need the `Term`s of the `Unit`.
 - Added `unit` constant: `UNITY`
 - Added `term` constants: `UNITY`, `UNITY_ARRAY`, and `UNITY_ARRAY_REF`.
@@ -62,6 +64,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - NAUM-7 (Internal): Updated `Convertible` implementation for `Measurement` to:
   1. skip the `field_eq()` check when converting,
   2. remove unnecessary `.clone()` call when converting from a `&str`.
+- _BREAKING_ NAUM-8 (Internal): Refactored `convert::ToReduced` to simplify and speed up. The
+  potentially breaking part here is that where units of opposing dimensions (ex. `[acr_us]/m2/har`)
+  used to reduce to the first remainder unit (ex. `[acr_us]`), they now reduce to the last.
 
 ### Deprecated
 

--- a/crates/api/benches/unit_benchmarks.rs
+++ b/crates/api/benches/unit_benchmarks.rs
@@ -6,7 +6,7 @@ mod common;
 
 use criterion::{BenchmarkId, Criterion};
 use std::str::FromStr;
-use wise_units::{Composable, IsCompatibleWith, UcumUnit, Unit};
+use wise_units::{reduce::ToReduced, Composable, IsCompatibleWith, UcumUnit, Unit};
 
 macro_rules! bench_over_inputs_method {
     ($function_name:ident, $test_name:expr, $method_name:ident) => {
@@ -63,6 +63,34 @@ bench_over_inputs_method!(
     "Unit::expression_reduced()",
     expression_reduced
 );
+
+fn to_reduced_group(c: &mut Criterion) {
+    const REDUCIBLES: [&str; 7] = [
+        "m2",
+        "m4/m2",
+        "har/m2",
+        "har2/m2",
+        "g.m2/har",
+        "g.m4/har",
+        "[acr_us]/m2/har/[sft_i]",
+    ];
+
+    let mut group = c.benchmark_group("Unit::to_reduced()");
+
+    for unit_str in REDUCIBLES {
+        group.bench_with_input(
+            BenchmarkId::new("to_reduced", unit_str),
+            &unit_str,
+            |b, unit_str| {
+                let unit = Unit::from_str(unit_str).unwrap();
+
+                b.iter(|| unit.to_reduced());
+            },
+        );
+    }
+
+    group.finish()
+}
 
 //-----------------------------------------------------------------------------
 // impl Composable
@@ -139,6 +167,7 @@ criterion_group!(
     magnitude_group,
     expression_group,
     expression_reduced_group,
+    to_reduced_group,
     composition_group,
     is_compatible_with_group,
     display_group,

--- a/crates/api/src/composition.rs
+++ b/crates/api/src/composition.rs
@@ -1,5 +1,7 @@
 use std::{fmt, ops::Mul};
 
+use num_traits::Inv;
+
 use crate::{term::Exponent, Dimension};
 
 pub const DIMLESS: Composition = Composition::new_dimless();
@@ -449,6 +451,22 @@ impl From<Dimension> for Composition {
             Dimension::PlaneAngle => Self::new_plane_angle(1),
             Dimension::Temperature => Self::new_temperature(1),
             Dimension::Time => Self::new_time(1),
+        }
+    }
+}
+
+impl Inv for Composition {
+    type Output = Self;
+
+    fn inv(self) -> Self::Output {
+        Self {
+            electric_charge: self.electric_charge.map(|e| -e),
+            length: self.length.map(|e| -e),
+            luminous_intensity: self.luminous_intensity.map(|e| -e),
+            mass: self.mass.map(|e| -e),
+            plane_angle: self.plane_angle.map(|e| -e),
+            temperature: self.temperature.map(|e| -e),
+            time: self.time.map(|e| -e),
         }
     }
 }

--- a/crates/api/src/measurement/to_reduced.rs
+++ b/crates/api/src/measurement/to_reduced.rs
@@ -92,9 +92,9 @@ mod tests {
         );
 
         validate_reduction!(
-            validate_acr_us_per_m2_per_har,
+            validate_har_per_m2_per_acr_us,
             1.0,
-            "[acr_us]/m2/har",
+            "har/m2/[acr_us]",
             10_000.0,
             "[acr_us]"
         );
@@ -160,9 +160,9 @@ mod tests {
         );
 
         validate_reduction!(
-            validate_acr_us_per_m2_per_har,
+            validate_har_per_m2_per_acr_us,
             1.0,
-            "[acr_us]/m2/har",
+            "har/m2/[acr_us]",
             10_000.0,
             "[acr_us]"
         );

--- a/crates/api/src/measurement/v2/convert.rs
+++ b/crates/api/src/measurement/v2/convert.rs
@@ -1,6 +1,6 @@
 use crate::{
     unit,
-    v2::convert::{ToFraction, TryConvertTo},
+    v2::convert::{ToFraction, TryConvertTo, TryToReduced},
     Error, Measurement, Unit,
 };
 
@@ -44,6 +44,15 @@ impl<'a> TryConvertTo<&'a Unit> for Measurement {
     fn try_convert_to(&self, rhs: &'a Unit) -> Result<Self, Self::Error> {
         // Delegate to old implementation for now.
         crate::Convertible::convert_to(self, rhs)
+    }
+}
+
+impl TryToReduced for Measurement {
+    type Error = Error;
+
+    fn try_to_reduced(&self) -> Result<Self, Self::Error> {
+        // Just delegate to the old trait impl for now.
+        crate::reduce::ToReduced::to_reduced(self)
     }
 }
 

--- a/crates/api/src/reduce.rs
+++ b/crates/api/src/reduce.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::doc_markdown)]
+
 /// Defines an interface for reducing `Unit`s and `Measurements`, where "reducing" is on cancelling
 /// out `Unit`s that have the same dimension (ex. "[acr_us]" and "har" both have the dimension
 /// "L2", so they can effectively be canceled out).

--- a/crates/api/src/unit/v2/convert.rs
+++ b/crates/api/src/unit/v2/convert.rs
@@ -1,4 +1,8 @@
-use crate::{as_fraction::AsFraction, v2::convert::ToFraction, Unit};
+use crate::{
+    as_fraction::AsFraction,
+    v2::convert::{ToFraction, ToReduced},
+    Unit,
+};
 
 impl ToFraction for Unit {
     fn to_fraction(&self) -> (Option<Self>, Option<Self>) {
@@ -14,6 +18,13 @@ impl ToFraction for Unit {
     fn to_denominator(&self) -> Option<Self> {
         // Just delegate to the old trait impl for now.
         AsFraction::denominator(self)
+    }
+}
+
+impl ToReduced for Unit {
+    fn to_reduced(&self) -> Self {
+        // Just delegate to the old trait impl for now.
+        crate::reduce::ToReduced::to_reduced(self)
     }
 }
 


### PR DESCRIPTION
For NAUM-8, this:

1. Adds the new `v2` traits
2. Implements `v2::ToReduced` for `Unit` and `v2::TryToReduced` for `Measurement`
3. Adds benchmarks for the existing `convert::ToReduced` implementation
4. Refactors the existing `convert::ToReduced` implementation for simplicity and speed. Note that this _might_ be a breaking change in some cases; while the scalar value of the Unit isn't effected, the resulting representation can change in some cases. 4 tests illustrate this change; I'll call those out directly. @tindron didn't think this would affect any Rails code since they're more apt to convert specifically to the unit they want to use in the given context.