### PR TITLE
Replace actions-rs GH actions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -33,17 +33,15 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo test all
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features
+        run: cargo test --workspace --all-features
 
   check-ios:
     name: Test (x86_64-apple-ios)
     runs-on: [self-hosted, macOS, xcode13]
     if: ${{ false }} # Disabling till PCC-221
     env:
-      DYLD_ROOT_PATH: "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app"
+      DYLD_ROOT_PATH: >
+        "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app"
     steps:
       - uses: actions/checkout@v4
       - name: Setup SSH
@@ -59,14 +57,11 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-apple-ios
-          override: true
+          targets: "x86_64-apple-ios"
       - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --package wise_units-ffi --all-features --target x86_64-apple-ios
+        run: >
+          cargo test --package wise_units-ffi
+          --all-features
+          --target x86_64-apple-ios

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -36,6 +36,6 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Security audit
-        uses: actions-rs/audit-check@v1
+        uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Initially I thought the only remaining actions-rs actions were `audit-check`, but turns out there
were more, so I went ahead and replaced them all.

- **NAUM-104 Replace actions-rs/audit-check with rustsec/audit-check**
- **NAUM-104 Replace remaining actions-rs actions**
