### PR TITLE
Update ffi crate for 0.23.0 changes

### DIFF
--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -10,7 +10,7 @@ publish = ["agrian-registry"]
 
 [dependencies]
 ffi_common.workspace = true
-wise_units = { version = "0.22", registry = "agrian-registry" }
+wise_units = { version = "0.23", registry = "agrian-registry" }
 
 [build-dependencies]
 cbindgen = "0.26.0"

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -19,17 +19,18 @@
 // C bindings don't include the module name, so ffi functions will need it.
 #![allow(clippy::module_name_repetitions)]
 
-use ffi_common::core;
-use std::{convert::TryInto, os::raw::c_char, ptr};
 pub mod measurement;
 pub mod unit;
 
+use std::{convert::TryInto, os::raw::c_char, ptr};
+
+use ffi_common::core;
 pub use wise_units::{Measurement, Unit};
 
 #[allow(clippy::needless_pass_by_value)]
 fn set_error_and_return<T>(message: String) -> *const T {
     core::error::set_last_err_msg(&message);
-    std::ptr::null()
+    ptr::null()
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/crates/ffi/src/measurement.rs
+++ b/crates/ffi/src/measurement.rs
@@ -1,5 +1,6 @@
-use ffi_common::core::error;
 use std::{ffi::CStr, os::raw::c_char, ptr};
+
+use ffi_common::core::error;
 use wise_units::{reduce::ToReduced, Convertible, Measurement, UcumUnit, Unit};
 
 /// Create a new `Measurement`. Note that you must call
@@ -400,7 +401,7 @@ mod tests {
 
     #[test]
     fn can_reduce() {
-        let expression = CString::new("[acr_us]/m2/har").expect("CString::new failed");
+        let expression = CString::new("har/m2/[acr_us]").expect("CString::new failed");
         let value = 1.0;
         let expected_expression = "[acr_us]";
         let expected_value = 10_000.0;

--- a/crates/ffi/src/measurement.rs
+++ b/crates/ffi/src/measurement.rs
@@ -304,7 +304,7 @@ pub unsafe extern "C" fn measurement_div_scalar(
 mod tests {
     use super::*;
     use approx::{assert_relative_eq, assert_ulps_eq};
-    use ffi_common::core;
+
     use std::ffi::CString;
 
     #[test]
@@ -516,7 +516,7 @@ mod tests {
             let m = measurement_new(value, expression1.as_ptr());
             let converted = measurement_convert_to(m, expression2.as_ptr());
             assert_eq!(converted, ptr::null());
-            let error = CStr::from_ptr(core::error::get_last_err_msg());
+            let error = CStr::from_ptr(error::get_last_err_msg());
             let error_str = error.to_str().expect("Failed to get str from CStr");
             assert_eq!(error_str, expected_error);
         }
@@ -533,11 +533,11 @@ mod tests {
             // result is null, error is not null
             let conversion_result_1 = measurement_convert_to(m, expression2.as_ptr());
             assert_eq!(conversion_result_1, ptr::null());
-            assert_ne!(core::error::get_last_err_msg(), ptr::null());
+            assert_ne!(error::get_last_err_msg(), ptr::null());
             // result is not null, error is null
             let conversion_result_2 = measurement_convert_to(m, expression3.as_ptr());
             assert_ne!(conversion_result_2, ptr::null());
-            assert_eq!(core::error::get_last_err_msg(), ptr::null());
+            assert_eq!(error::get_last_err_msg(), ptr::null());
         }
     }
 }

--- a/crates/ffi/src/unit.rs
+++ b/crates/ffi/src/unit.rs
@@ -1,14 +1,16 @@
-use crate::move_string_to_buffer;
-use ffi_common::core::error;
 use std::{
     ffi::{CStr, CString},
     os::raw::c_char,
     ptr,
     str::FromStr,
 };
+
+use ffi_common::core::error;
 use wise_units::{
-    is_compatible_with::IsCompatibleWith, parser::Composable, reduce::ToReduced, UcumUnit, Unit,
+    is_compatible_with::IsCompatibleWith, reduce::ToReduced, Composable, UcumUnit, Unit,
 };
+
+use crate::move_string_to_buffer;
 
 /// Create a new `Unit`. Note that you must call `unit_destroy(data: unit)` with
 /// this instance when you are done with it so that the the unit can be properly
@@ -404,7 +406,7 @@ mod tests {
         unsafe {
             let unit = unit_new(expression.as_ptr());
             let reduced = unit_reduced(unit);
-            assert_eq!((*reduced).expression().as_str(), "/m2.cm.km");
+            assert_eq!((*reduced).expression().as_str(), "/km3.cm");
         }
     }
 

--- a/crates/ffi/src/unit.rs
+++ b/crates/ffi/src/unit.rs
@@ -267,7 +267,7 @@ pub unsafe extern "C" fn unit_composition_buf(
 mod tests {
     use super::*;
     use approx::{assert_relative_eq, assert_ulps_eq};
-    use ffi_common::core;
+
     use std::ffi::CString;
 
     #[test]
@@ -289,7 +289,7 @@ mod tests {
         unsafe {
             let u = unit_new(expression.as_ptr());
             assert_eq!(u, ptr::null());
-            let error = CStr::from_ptr(core::error::get_last_err_msg())
+            let error = CStr::from_ptr(error::get_last_err_msg())
                 .to_str()
                 .expect("Failed to get str from CStr.");
             assert_eq!(error, expected_error);


### PR DESCRIPTION
I forgot to update these when I did the last PR, and we need these changes in `agrian_units` to
keep the ffi parts compiling over there.

- **NAUM-103 Update ffi crate with api changes**
- **clippy --fix**
