### PR TITLE
Bump to 0.24.0; fix old agrian package settings

### DIFF
--- a/crates/api/CHANGELOG.md
+++ b/crates/api/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [0.24.0] — 2025-03-11
 
 ### Added
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wise_units"
-version = "0.22.0"
+version = "0.24.0"
 description = "Measure things using UCUM units"
-repository = "https://github.com/agrian-inc/wise_units"
+repository = "https://github.com/telus-agcg/wise_units"
 license = "MIT"
-authors = ["Steve Loveless <steve@agrian.com>"]
+authors = ["Steve Loveless <steve@telusagcg.com>"]
 edition = "2021"
 publish = ["agrian-registry"]
 
@@ -15,7 +15,7 @@ num-traits = "0.2"
 pest = "^2.1"
 pest_derive = "^2.1"
 serde = { workspace = true, optional = true }
-thiserror = "1.0"
+thiserror = "2.0"
 
 [dev-dependencies]
 bincode = "1.3"

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wise_units-ffi"
-version = "0.22.0"
+version = "0.24.0"
 description = "FFI wrapper for wise_units"
-repository = "https://github.com/agrian-inc/wise_units"
+repository = "https://github.com/telus-agcg/wise_units"
 license = "MIT"
-authors = ["Nicholas Smillie <nicholas@agrian.com>"]
+authors = ["Nicholas Smillie <nicholas@telusagcg.com>"]
 edition = "2021"
 publish = ["agrian-registry"]
 

--- a/crates/ffi/Changelog.md
+++ b/crates/ffi/Changelog.md
@@ -5,19 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.22.1] - 2022-03-23
+## [0.24.0] — 2025-03-11
+
+- Updated with `wise_units` 0.24.0.
+
+## [0.23.0]
+
+- Yanked!
+
+## [0.22.1] — 2022-03-23
 
 ### Fixed
 
 - Actually point this crate to `wise_units` 0.22.0 🤦.
 
-## [0.22.0] - 2022-03-23
+## [0.22.0] — 2022-03-23
 
 ### Changed
 
 - Updated to Rust edition `2021`.
 
-## [0.21.1] - 2021-11-19
+## [0.21.1] — 2021-11-19
 
 ### Changed
 
@@ -25,11 +33,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `ffi_common` to 0.7.0.
   - `wise_units` to 0.21.1.
 
-## [0.21.0] - 2021-10-20
+## [0.21.0] — 2021-10-20
 
 - No changes.
 
-## [0.20.0] - 2021-09-29
+## [0.20.0] — 2021-09-29
 
 ### Changed
 
@@ -37,31 +45,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `ffi_common` to 0.6.0.
   - `wise_units` to 0.20.0.
 
-## [0.19.0] - 2021-09-22
+## [0.19.0] — 2021-09-22
 
 ### Changed
 
 - Update `ffi_common` to 0.5.0.
 
-## [0.18.0] - 2021-08-11
+## [0.18.0] — 2021-08-11
 
 ### Changed
 
 - Updated to use `Measurement::try_new()`.
 - Update `ffi_common` to 0.4.0.
 
-## [0.17.1] - 2021-07-16
+## [0.17.1] — 2021-07-16
 
 ### Changed
 
 - Update `ffi_common` to 0.3.0.
 
-## [0.17.0] - 2021-07-16
+## [0.17.0] — 2021-07-16
 
 ### Fixed
 
 - Use manual `drop()` for `measurement_destroy()` and `unit_destroy()`.
 
-## [0.16.0] - 2020-12-16
+## [0.16.0] — 2020-12-16
 
 (Changes not captured here yet.)


### PR DESCRIPTION
- NAUM-144
- NAUM-146

This contains all 0.23 and 0.24 content, as 0.23 was yanked due to a bug last year.